### PR TITLE
Session free transaction handling

### DIFF
--- a/Magento2x_PayUBiz/PayUIndia/Payu/Controller/PayuAbstract.php
+++ b/Magento2x_PayUBiz/PayUIndia/Payu/Controller/PayuAbstract.php
@@ -128,12 +128,13 @@ abstract class PayuAbstract extends \Magento\Framework\App\Action\Action
     /**
      * Get order object
      *
+     * @param $orderId
      * @return \Magento\Sales\Model\Order
      */
-    protected function getOrder()
+    protected function getOrder($orderId)
     {
         return $this->_orderFactory->create()->loadByIncrementId(
-            $this->_checkoutSession->getLastRealOrderId()
+            $orderId
         );
     }
 

--- a/Magento2x_PayUBiz/PayUIndia/Payu/Controller/Standard/Cancel.php
+++ b/Magento2x_PayUBiz/PayUIndia/Payu/Controller/Standard/Cancel.php
@@ -5,8 +5,11 @@ namespace PayUIndia\Payu\Controller\Standard;
 class Cancel extends \PayUIndia\Payu\Controller\PayuAbstract {
 
     public function execute() {
-        $this->getOrder()->cancel()->save();
-        
+        $paymentMethod = $this->getPaymentMethod();
+        $params = $this->getRequest()->getParams();
+        $orderId = $paymentMethod->getDecryptOrderId($params["uniqId"]);
+        $this->getOrder($orderId)->cancel()->save();
+
         $this->messageManager->addErrorMessage(__('Your order has been can cancelled'));
         $this->getResponse()->setRedirect(
                 $this->getCheckoutHelper()->getUrl('checkout')

--- a/Magento2x_PayUBiz/PayUIndia/Payu/Controller/Standard/Response.php
+++ b/Magento2x_PayUBiz/PayUIndia/Payu/Controller/Standard/Response.php
@@ -10,11 +10,12 @@ class Response extends \PayUIndia\Payu\Controller\PayuAbstract {
         try {
             $paymentMethod = $this->getPaymentMethod();
             $params = $this->getRequest()->getParams();
+            $orderId = $paymentMethod->getDecryptOrderId($params["uniqId"]);
 
             if ($paymentMethod->validateResponse($params)) {
 
                 $returnUrl = $this->getCheckoutHelper()->getUrl('checkout/onepage/success');
-                $order = $this->getOrder();
+                $order = $this->getOrder($orderId);
                 $payment = $order->getPayment();
                 $paymentMethod->postProcessing($order, $payment, $params);
             } else {

--- a/Magento2x_PayUBiz/PayUIndia/Payu/Controller/Standard/Response.php
+++ b/Magento2x_PayUBiz/PayUIndia/Payu/Controller/Standard/Response.php
@@ -11,11 +11,10 @@ class Response extends \PayUIndia\Payu\Controller\PayuAbstract {
             $paymentMethod = $this->getPaymentMethod();
             $params = $this->getRequest()->getParams();
             $orderId = $paymentMethod->getDecryptOrderId($params["uniqId"]);
+            $order = $this->getOrder($orderId);
 
-            if ($paymentMethod->validateResponse($params)) {
-
+            if (!empty($orderId) && $paymentMethod->validateResponse($params, $order)) {
                 $returnUrl = $this->getCheckoutHelper()->getUrl('checkout/onepage/success');
-                $order = $this->getOrder($orderId);
                 $payment = $order->getPayment();
                 $paymentMethod->postProcessing($order, $payment, $params);
             } else {

--- a/Magento2x_PayUBiz/PayUIndia/Payu/Controller/Standard/Response.php
+++ b/Magento2x_PayUBiz/PayUIndia/Payu/Controller/Standard/Response.php
@@ -12,7 +12,7 @@ class Response extends \PayUIndia\Payu\Controller\PayuAbstract {
             $params = $this->getRequest()->getParams();
             $orderId = $paymentMethod->getDecryptOrderId($params["uniqId"]);
             $result = false;
-            if ($paymentMethod->validateResponse($params)  && $orderId == $params["productinfo"]) {
+            if ($orderId == $params["productinfo"] && $paymentMethod->validateResponse($params)) {
                 $returnUrl = $this->getCheckoutHelper()->getUrl('checkout/onepage/success');
                 $order = $this->getOrder($orderId);
                 $payment = $order->getPayment();

--- a/Magento2x_PayUBiz/PayUIndia/Payu/Controller/Standard/Response.php
+++ b/Magento2x_PayUBiz/PayUIndia/Payu/Controller/Standard/Response.php
@@ -11,13 +11,17 @@ class Response extends \PayUIndia\Payu\Controller\PayuAbstract {
             $paymentMethod = $this->getPaymentMethod();
             $params = $this->getRequest()->getParams();
             $orderId = $paymentMethod->getDecryptOrderId($params["uniqId"]);
-            $order = $this->getOrder($orderId);
-
-            if (!empty($orderId) && $paymentMethod->validateResponse($params, $order)) {
+            $result = false;
+            if ($paymentMethod->validateResponse($params)  && $orderId == $params["productinfo"]) {
                 $returnUrl = $this->getCheckoutHelper()->getUrl('checkout/onepage/success');
+                $order = $this->getOrder($orderId);
                 $payment = $order->getPayment();
-                $paymentMethod->postProcessing($order, $payment, $params);
-            } else {
+                if($params["amount"] == round($order->getBaseGrandTotal(), 2)){;
+                    $paymentMethod->postProcessing($order, $payment, $params);
+                    $result =  true;
+                }
+            }
+            if($result == false){
                 $this->messageManager->addErrorMessage(__('Payment failed. Please try again or choose a different payment method'));
                 $returnUrl = $this->getCheckoutHelper()->getUrl('checkout/onepage/failure');
             }

--- a/Magento2x_PayUBiz/PayUIndia/Payu/Model/Payu.php
+++ b/Magento2x_PayUBiz/PayUIndia/Payu/Model/Payu.php
@@ -187,7 +187,7 @@ class Payu extends \Magento\Payment\Model\Method\AbstractMethod {
     }
 
     //validate response
-    public function validateResponse($returnParams) {
+    public function validateResponse($returnParams, \Magento\Sales\Model\Order $order) {
         if ($returnParams['status'] == 'pending' || $returnParams['status'] == 'failure') {
             return false;
         }
@@ -213,7 +213,7 @@ class Payu extends \Magento\Payment\Model\Method\AbstractMethod {
 		 	$Udf10 = $returnParams['udf10'];
 			
 			$keyString =  $this->getConfigData("merchant_key").'|'.$txnid.'|'.$amount.'|'.$productinfo.'|'.$firstname.'|'.$email.'|'.$Udf1.'|'.$Udf2.'|'.$Udf3.'|'.$Udf4.'|'.$Udf5.'|'.$Udf6.'|'.$Udf7.'|'.$Udf8.'|'.$Udf9.'|'.$Udf10;
-		  
+            $amountChecked = ($amount == round($order->getBaseGrandTotal(), 2));
 			$keyArray = explode("|",$keyString);
 			$reverseKeyArray = array_reverse($keyArray);
 			$reverseKeyString=implode("|",$reverseKeyArray);			 
@@ -224,7 +224,7 @@ class Payu extends \Magento\Payment\Model\Method\AbstractMethod {
 			if($sentHashString != $returnParams['hash'])
 				return false;
 			else
-				return true;
+				return $amountChecked;
 		}
         return false;
     }

--- a/Magento2x_PayUBiz/PayUIndia/Payu/Model/Payu.php
+++ b/Magento2x_PayUBiz/PayUIndia/Payu/Model/Payu.php
@@ -129,7 +129,6 @@ class Payu extends \Magento\Payment\Model\Method\AbstractMethod {
         $params["zip"]                  = $billing_address->getPostcode();
         $params["country"]              = $billing_address->getCountryId();
         $params["email"] = $order->getCustomerEmail();
-        $params["udf3"] = $this->checkoutSession->getLastRealOrderId();
         $params["udf5"] = 'Magento_v.2.1.3';
         $params["phone"] = $billing_address->getTelephone();
         $params["curl"] = $this->getCancelUrl()."?uniqId=".$encryptOrderId;
@@ -188,7 +187,7 @@ class Payu extends \Magento\Payment\Model\Method\AbstractMethod {
     }
 
     //validate response
-    public function validateResponse($returnParams, \Magento\Sales\Model\Order $order) {
+    public function validateResponse($returnParams) {
         if ($returnParams['status'] == 'pending' || $returnParams['status'] == 'failure') {
             return false;
         }
@@ -214,8 +213,6 @@ class Payu extends \Magento\Payment\Model\Method\AbstractMethod {
 		 	$Udf10 = $returnParams['udf10'];
 			
 			$keyString =  $this->getConfigData("merchant_key").'|'.$txnid.'|'.$amount.'|'.$productinfo.'|'.$firstname.'|'.$email.'|'.$Udf1.'|'.$Udf2.'|'.$Udf3.'|'.$Udf4.'|'.$Udf5.'|'.$Udf6.'|'.$Udf7.'|'.$Udf8.'|'.$Udf9.'|'.$Udf10;
-            $amountChecked = ($amount == round($order->getBaseGrandTotal(), 2));
-            $orderIdChecked = ($Udf3 == $order->getId());
 			$keyArray = explode("|",$keyString);
 			$reverseKeyArray = array_reverse($keyArray);
 			$reverseKeyString=implode("|",$reverseKeyArray);			 
@@ -226,7 +223,7 @@ class Payu extends \Magento\Payment\Model\Method\AbstractMethod {
 			if($sentHashString != $returnParams['hash'])
 				return false;
 			else
-                return $amountChecked && $orderIdChecked;
+                return true;
 		}
         return false;
     }

--- a/Magento2x_PayUBiz/PayUIndia/Payu/Model/Payu.php
+++ b/Magento2x_PayUBiz/PayUIndia/Payu/Model/Payu.php
@@ -129,7 +129,8 @@ class Payu extends \Magento\Payment\Model\Method\AbstractMethod {
         $params["zip"]                  = $billing_address->getPostcode();
         $params["country"]              = $billing_address->getCountryId();
         $params["email"] = $order->getCustomerEmail();
-		$params["udf5"] = 'Magento_v.2.1.3';
+        $params["udf3"] = $this->checkoutSession->getLastRealOrderId();
+        $params["udf5"] = 'Magento_v.2.1.3';
         $params["phone"] = $billing_address->getTelephone();
         $params["curl"] = $this->getCancelUrl()."?uniqId=".$encryptOrderId;
         $params["furl"] = $this->getReturnUrl()."?uniqId=".$encryptOrderId;
@@ -214,6 +215,7 @@ class Payu extends \Magento\Payment\Model\Method\AbstractMethod {
 			
 			$keyString =  $this->getConfigData("merchant_key").'|'.$txnid.'|'.$amount.'|'.$productinfo.'|'.$firstname.'|'.$email.'|'.$Udf1.'|'.$Udf2.'|'.$Udf3.'|'.$Udf4.'|'.$Udf5.'|'.$Udf6.'|'.$Udf7.'|'.$Udf8.'|'.$Udf9.'|'.$Udf10;
             $amountChecked = ($amount == round($order->getBaseGrandTotal(), 2));
+            $orderIdChecked = ($Udf3 == $order->getId());
 			$keyArray = explode("|",$keyString);
 			$reverseKeyArray = array_reverse($keyArray);
 			$reverseKeyString=implode("|",$reverseKeyArray);			 
@@ -224,7 +226,7 @@ class Payu extends \Magento\Payment\Model\Method\AbstractMethod {
 			if($sentHashString != $returnParams['hash'])
 				return false;
 			else
-				return $amountChecked;
+                return $amountChecked && $orderIdChecked;
 		}
         return false;
     }

--- a/Magento2x_PayUBiz/PayUIndia/Payu/etc/adminhtml/system.xml
+++ b/Magento2x_PayUBiz/PayUIndia/Payu/etc/adminhtml/system.xml
@@ -29,6 +29,10 @@
                     <label>Salt Key</label>
                     <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                 </field>
+                <field id="iv_value" translate="label" type="obscure" sortOrder="54" showInDefault="1" showInWebsite="1" showInStore="0">
+                    <label>IV Value (16 characters)</label>
+                    <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+                </field>
             </group>
         </section>
     </system>

--- a/Magento2x_PayUBiz/PayUIndia/Payu/etc/config.xml
+++ b/Magento2x_PayUBiz/PayUIndia/Payu/etc/config.xml
@@ -16,6 +16,7 @@
                 <cancel_url>payu/standard/cancel</cancel_url>
                 <merchant_key backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
                 <salt backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
+                <iv_value backend_model="Magento\Config\Model\Config\Backend\Encrypted" />
             </payu>
         </payment>
     </default>


### PR DESCRIPTION
Removing dependencies on PHP session cookie for transaction handling. 

**NOTE:** OrderID is being passed in `udf3`. Make sure `udf3` is not used for any other purpose in the API integration. 